### PR TITLE
feat: implement rate limiting for Plex API requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ docker run -d \
   -e ADD_PLAYLIST_DESCRIPTION=          # <1 or 0>, Default 1, 1 = add description for each playlist
   -e APPEND_INSTEAD_OF_SYNC=            # <0 or 1>, Default 0, 1 = Sync tracks, 0 = Append only
   -e SECONDS_TO_WAIT=84000              # Seconds to wait between syncs
+  -e MAX_REQUESTS_PER_SECOND=5          # Max Plex API requests per second (Default 5, lower for slow servers)
+  -e MAX_CONCURRENT_REQUESTS=4          # Max concurrent Plex requests (Default 4, lower to reduce CPU load)
   -e SPOTIFY_CLIENT_ID=                 # Your Spotify Client/App ID
   -e SPOTIFY_CLIENT_SECRET=             # Your Spotify client secret
   -e SPOTIFY_USER_ID=                   # Spotify ID to sync (Sync's all playlist)
@@ -79,6 +81,16 @@ docker run -d \
 #### Notes
 - Include `http://` or `https://` in the PLEX_URL
 - Remove comments (e.g.  `# Optional x`) before running 
+
+#### Rate Limiting for Slower Servers
+If your Plex server has limited CPU resources (e.g., Synology NAS, Raspberry Pi, or older hardware) and you experience high CPU usage or connection pool warnings like `Connection pool is full, discarding connection`, try lowering the rate limiting settings:
+
+```
+-e MAX_REQUESTS_PER_SECOND=2
+-e MAX_CONCURRENT_REQUESTS=2
+```
+
+This will significantly reduce the load on your Plex server at the cost of slightly longer sync times.
 
 ### Docker Compose
 
@@ -101,6 +113,8 @@ services:
       - ADD_PLAYLIST_DESCRIPTION=# <1 or 0>, Default 1, 1 = add description for each playlist
       - APPEND_INSTEAD_OF_SYNC=  # <0 or 1>, Default 0, 1 = Sync tracks, 0 = Append only
       - SECONDS_TO_WAIT=84000    # Seconds to wait between syncs
+      - MAX_REQUESTS_PER_SECOND=5  # Max Plex API requests per second (Default 5)
+      - MAX_CONCURRENT_REQUESTS=4  # Max concurrent Plex requests (Default 4)
       - SPOTIFY_CLIENT_ID=       # your spotify client id
       - SPOTIFY_CLIENT_SECRET=   # your spotify client secret
       - SPOTIFY_USER_ID=         # your spotify user id

--- a/assets/compose.yaml
+++ b/assets/compose.yaml
@@ -11,6 +11,8 @@ services:
       - ADD_PLAYLIST_DESCRIPTION=1
       - APPEND_INSTEAD_OF_SYNC=0
       - SECONDS_TO_WAIT=84000
+      - MAX_REQUESTS_PER_SECOND=5
+      - MAX_CONCURRENT_REQUESTS=4
       - SPOTIFY_CLIENT_ID=<your spotify client id>
       - SPOTIFY_CLIENT_SECRET=<your spotify client secret>
       - SPOTIFY_USER_ID=<your spotify user id>

--- a/plexist/modules/helperClasses.py
+++ b/plexist/modules/helperClasses.py
@@ -31,6 +31,10 @@ class UserInputs:
     append_instead_of_sync: bool
     wait_seconds: int
 
+    # Rate limiting settings
+    max_requests_per_second: float
+    max_concurrent_requests: int
+
     spotipy_client_id: str
     spotipy_client_secret: str
     spotify_user_id: str


### PR DESCRIPTION
Limited concurrent workers - ThreadPoolExecutor now uses a configurable max_workers instead of unlimited concurrency.

Rate-limited all Plex API calls:
fetch_plex_tracks() - Cache building requests
plex.search() within _match_single_track() - Track matching requests Improved background cache fetching:
Increased batch size from 100 to 500 tracks (fewer total requests) Added 0.5s delay between batches
Added error handling with 2s backoff on failures

Updated configuration:
Added max_requests_per_second and max_concurrent_requests to UserInputs dataclass Added configure_rate_limiting() function called at startup Updated README.md and compose.yaml with new options