### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,5 +1,8 @@
 name: DockerHub
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Gyarbij/Plexist/security/code-scanning/2](https://github.com/Gyarbij/Plexist/security/code-scanning/2)

In general, the fix is to declare a `permissions` block to scope down the `GITHUB_TOKEN` to the least privilege necessary. For this workflow, the steps only need to read the repository contents for checkout; all external writes (to Docker Hub) use separate secrets, not the `GITHUB_TOKEN`. Therefore, we can safely set `contents: read` and leave all other permissions unset (implicitly `none`).

The best minimal fix without changing existing functionality is to add a workflow-level `permissions` block near the top of `.github/workflows/image.yml`, just after the `name:` (or before/after `on:`). This block will apply to all jobs in the workflow, including the `docker` job, and will ensure the `GITHUB_TOKEN` has only read access to repository contents. No imports, additional methods, or other definitions are required, because this is pure workflow configuration.

Concretely:
- Edit `.github/workflows/image.yml`.
- Insert:
  ```yaml
  permissions:
    contents: read
  ```
  between line 2 and line 3 (i.e., after `name: DockerHub` and before `on:`).  
This will satisfy CodeQL’s requirement for an explicit permissions block and adhere to least-privilege principles.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
