### PR TITLE
Multi service sync

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -28,10 +28,19 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       -
-        name: Build and push
+        name: Build and push (amd64, arm64)
         uses: docker/build-push-action@v4
         with:
           context: .
-          platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
+          platforms: linux/amd64,linux/arm64/v8
+          push: true
+          tags: gyarbij/plexist:latest
+      -
+        name: Build and push (arm/v7)
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: Dockerfile.armv7
+          platforms: linux/arm/v7
           push: true
           tags: gyarbij/plexist:latest

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -1,0 +1,40 @@
+# ---------- builder (arm/v7 with build tools for cffi) ----------
+FROM python:3.14.2-slim AS builder
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /build
+COPY requirements.txt .
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      libsqlite3-0 \
+      libgcc-s1 \
+      libstdc++6 \
+      build-essential \
+      libffi-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python -m venv /opt/venv \
+ && /opt/venv/bin/python -m pip install --upgrade pip \
+ && /opt/venv/bin/pip install --no-cache-dir --only-binary=:all: --no-binary=pyaes,ratelimit,mpegdash,cffi,pycparser -r requirements.txt
+
+# ---------- runtime ----------
+FROM gcr.io/distroless/cc-debian13:nonroot AS runtime
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PATH="/opt/venv/bin:/usr/local/bin:$PATH" \
+    LD_LIBRARY_PATH="/lib:/usr/lib:/usr/local/lib"
+
+WORKDIR /app
+
+COPY --from=builder /usr/local /usr/local
+
+COPY --from=builder /opt/venv /opt/venv
+COPY plexist /app/plexist
+
+COPY --from=builder /lib/ /lib/
+COPY --from=builder /usr/lib/ /usr/lib/
+
+USER 65532
+CMD ["python", "plexist/plexist.py"]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 | **Auto Updates** | Keeps playlists in sync with your streaming services |
 | **New Playlists** | Automatically creates Plex playlists when added to your streaming service |
 | **Liked Tracks** | Syncs favorited tracks to Plex as 5-star ratings (appears in "Liked Tracks" smart playlist) |
-| **ISRC Matching** | Uses ISRC codes for accurate track matching across services |
+| **ISRC Matching** | Uses ISRC codes for accurate track matching (falls back to fuzzy matching) |
 
 ### Supported Services
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@
 | Feature | Description |
 |---------|-------------|
 | **Playlist Sync** | Recreates your streaming playlists in Plex using files from your library |
+| **Multi-Service Sync** | Sync playlists between any services (e.g., Spotify → Qobuz, Tidal → Plex) |
 | **Auto Updates** | Keeps playlists in sync with your streaming services |
 | **New Playlists** | Automatically creates Plex playlists when added to your streaming service |
 | **Liked Tracks** | Syncs favorited tracks to Plex as 5-star ratings (appears in "Liked Tracks" smart playlist) |
+| **ISRC Matching** | Uses ISRC codes for accurate track matching across services |
 
 ### Supported Services
 
@@ -27,6 +29,47 @@
 - **Apple Music**
 - **Tidal**
 - **Qobuz**
+
+### Multi-Service Sync
+
+Sync playlists between any two services — not just to Plex! Configure source → destination pairs to sync playlists directly between streaming services.
+
+#### Supported Sync Directions
+
+| Service | Read (Source) | Write (Destination) |
+|---------|:-------------:|:-------------------:|
+| Spotify | ✅ | ❌ |
+| Deezer | ✅ | ❌ |
+| Apple Music | ✅ | ❌ |
+| Tidal | ✅ | ✅ |
+| Qobuz | ✅ | ✅ |
+| Plex | ✅ | ✅ |
+
+#### Configuration
+
+Set the `SYNC_PAIRS` environment variable with comma-separated `source:destination` pairs:
+
+```env
+# Sync Spotify playlists to Qobuz
+SYNC_PAIRS=spotify:qobuz
+
+# Sync Tidal playlists to Plex
+SYNC_PAIRS=tidal:plex
+
+# Multiple sync pairs
+SYNC_PAIRS=spotify:qobuz,tidal:plex,deezer:tidal
+```
+
+#### How It Works
+
+1. **Fetches playlists** from the source service
+2. **Matches tracks** in the destination using:
+   - **ISRC codes** (International Standard Recording Code) for exact matching
+   - **Metadata fallback** (title/artist/album) when ISRC unavailable
+3. **Creates or updates** playlists in the destination service
+4. **Reports results** including matched, missing, and failed tracks
+
+> **💡 Note:** When `SYNC_PAIRS` is configured, it replaces the default Plex-centric sync behavior. To sync to Plex, include it as a destination (e.g., `spotify:plex`).
 
 ## What it will NOT do:
 
@@ -245,6 +288,7 @@ All boolean options accept flexible values (case-insensitive):
 | `ADD_PLAYLIST_DESCRIPTION` | `yes` | Add description to playlists |
 | `APPEND_INSTEAD_OF_SYNC` | `no` | `no` = Full sync, `yes` = Append only (no removals) |
 | `SYNC_LIKED_TRACKS` | `no` | Sync liked tracks to Plex 5-star ratings |
+| `SYNC_PAIRS` | — | Multi-service sync pairs (e.g., `spotify:qobuz,tidal:plex`) |
 
 #### Output Options
 
@@ -370,6 +414,7 @@ services:
       ADD_PLAYLIST_DESCRIPTION: yes
       APPEND_INSTEAD_OF_SYNC: no
       SYNC_LIKED_TRACKS: no
+      # SYNC_PAIRS: spotify:qobuz,tidal:plex  # Multi-service sync (optional)
 
       # === Performance ===
       MAX_REQUESTS_PER_SECOND: 5

--- a/assets/example.env
+++ b/assets/example.env
@@ -55,6 +55,24 @@ LOG_FORMAT=plain
 SYNC_LIKED_TRACKS=0
 
 # ===========================================
+# MULTI-SERVICE SYNC
+# ===========================================
+# Sync playlists between any two services (not just to Plex)
+# Format: comma-separated pairs of source:destination
+# Examples:
+#   SYNC_PAIRS=spotify:qobuz             - Sync Spotify playlists to Qobuz
+#   SYNC_PAIRS=tidal:plex                - Sync Tidal playlists to Plex
+#   SYNC_PAIRS=spotify:qobuz,tidal:plex  - Multiple sync pairs
+#
+# Available services: spotify, deezer, apple_music, tidal, qobuz, plex
+# Note: Source must have read capability, destination must have write capability
+#       (Qobuz, Tidal, and Plex support write operations)
+#
+# Uses ISRC codes for accurate track matching when available,
+# falls back to title/artist/album matching otherwise.
+SYNC_PAIRS=
+
+# ===========================================
 # SPOTIFY CONFIGURATION
 # ===========================================
 # Get these from https://developer.spotify.com/dashboard

--- a/plexist/modules/apple_music.py
+++ b/plexist/modules/apple_music.py
@@ -314,6 +314,9 @@ def _extract_track_metadata(track_data: dict) -> Track:
     # Genre
     genre = attributes.get("genreNames", [""])[0] if attributes.get("genreNames") else ""
     
+    # Extract ISRC - Apple Music provides this in attributes
+    isrc = attributes.get("isrc")
+    
     return Track(
         title=title,
         artist=artist,
@@ -321,6 +324,7 @@ def _extract_track_metadata(track_data: dict) -> Track:
         url=url,
         year=year,
         genre=genre,
+        isrc=isrc,
     )
 
 

--- a/plexist/modules/base.py
+++ b/plexist/modules/base.py
@@ -1,31 +1,164 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable, List, Optional, Tuple
 
 from .helperClasses import Playlist, Track, UserInputs
 
 
 class MusicServiceProvider(ABC):
+    """Base class for music service providers.
+    
+    Providers can have read capabilities (fetching playlists/tracks from the service)
+    and/or write capabilities (creating playlists/adding tracks to the service).
+    """
     name: str
+    
+    # Capability flags - subclasses override these
+    supports_read: bool = True  # Can read playlists/tracks from service
+    supports_write: bool = False  # Can write playlists/tracks to service
 
     @abstractmethod
     def is_configured(self, user_inputs: UserInputs) -> bool:
+        """Check if the provider is properly configured."""
         raise NotImplementedError
 
     @abstractmethod
     async def get_playlists(self, user_inputs: UserInputs) -> List[Playlist]:
+        """Fetch all user playlists from the service."""
         raise NotImplementedError
 
     @abstractmethod
     async def get_tracks(
         self, playlist: Playlist, user_inputs: UserInputs
     ) -> List[Track]:
+        """Fetch all tracks from a playlist."""
         raise NotImplementedError
 
     @abstractmethod
     async def sync(self, plex, user_inputs: UserInputs) -> None:
+        """Legacy sync method - syncs to Plex. Kept for backwards compatibility."""
         raise NotImplementedError
+    
+    # ============================================================
+    # Write capability methods (optional - only for providers with supports_write=True)
+    # ============================================================
+    
+    async def search_track(
+        self, 
+        track: Track, 
+        user_inputs: UserInputs
+    ) -> Optional[str]:
+        """Search for a track in this service and return its service-specific ID.
+        
+        Uses ISRC for exact matching when available, falls back to metadata matching.
+        
+        Args:
+            track: Track to search for
+            user_inputs: User configuration
+            
+        Returns:
+            Service-specific track ID if found, None otherwise
+        """
+        raise NotImplementedError(f"{self.name} does not support track search")
+    
+    async def create_playlist(
+        self, 
+        playlist: Playlist, 
+        user_inputs: UserInputs
+    ) -> str:
+        """Create a new playlist in this service.
+        
+        Args:
+            playlist: Playlist metadata (name, description, poster)
+            user_inputs: User configuration
+            
+        Returns:
+            Service-specific playlist ID of the created playlist
+        """
+        raise NotImplementedError(f"{self.name} does not support playlist creation")
+    
+    async def add_tracks_to_playlist(
+        self,
+        playlist_id: str,
+        track_ids: List[str],
+        user_inputs: UserInputs
+    ) -> int:
+        """Add tracks to an existing playlist.
+        
+        Args:
+            playlist_id: Service-specific playlist ID
+            track_ids: List of service-specific track IDs to add
+            user_inputs: User configuration
+            
+        Returns:
+            Number of tracks successfully added
+        """
+        raise NotImplementedError(f"{self.name} does not support adding tracks to playlists")
+    
+    async def get_playlist_by_name(
+        self,
+        name: str,
+        user_inputs: UserInputs
+    ) -> Optional[Playlist]:
+        """Find an existing playlist by name.
+        
+        Args:
+            name: Playlist name to search for
+            user_inputs: User configuration
+            
+        Returns:
+            Playlist if found, None otherwise
+        """
+        # Default implementation: search through all playlists
+        playlists = await self.get_playlists(user_inputs)
+        for pl in playlists:
+            if pl.name.lower() == name.lower():
+                return pl
+        return None
+    
+    async def clear_playlist(
+        self,
+        playlist_id: str,
+        user_inputs: UserInputs
+    ) -> bool:
+        """Remove all tracks from a playlist.
+        
+        Args:
+            playlist_id: Service-specific playlist ID
+            user_inputs: User configuration
+            
+        Returns:
+            True if successful, False otherwise
+        """
+        raise NotImplementedError(f"{self.name} does not support clearing playlists")
+    
+    async def match_tracks(
+        self,
+        tracks: List[Track],
+        user_inputs: UserInputs
+    ) -> Tuple[List[Tuple[Track, str]], List[Track]]:
+        """Match a list of tracks to this service.
+        
+        Args:
+            tracks: List of tracks to match
+            user_inputs: User configuration
+            
+        Returns:
+            Tuple of (matched_tracks, missing_tracks) where matched_tracks
+            is a list of (original_track, service_track_id) tuples
+        """
+        matched: List[Tuple[Track, str]] = []
+        missing: List[Track] = []
+        
+        for track in tracks:
+            track_id = await self.search_track(track, user_inputs)
+            if track_id:
+                matched.append((track, track_id))
+            else:
+                missing.append(track)
+        
+        return matched, missing
 
 
 class ServiceRegistry:
@@ -40,6 +173,21 @@ class ServiceRegistry:
     @classmethod
     def providers(cls) -> Iterable[MusicServiceProvider]:
         return cls._providers.values()
+    
+    @classmethod
+    def get_provider(cls, name: str) -> Optional[MusicServiceProvider]:
+        """Get a provider by name."""
+        return cls._providers.get(name.lower())
+    
+    @classmethod
+    def get_write_capable_providers(cls) -> Iterable[MusicServiceProvider]:
+        """Get all providers that support writing playlists/tracks."""
+        return [p for p in cls._providers.values() if p.supports_write]
+    
+    @classmethod
+    def get_read_capable_providers(cls) -> Iterable[MusicServiceProvider]:
+        """Get all providers that support reading playlists/tracks."""
+        return [p for p in cls._providers.values() if p.supports_read]
 
     @classmethod
     async def sync_all(cls, plex, user_inputs: UserInputs) -> None:

--- a/plexist/modules/deezer.py
+++ b/plexist/modules/deezer.py
@@ -92,7 +92,9 @@ def extract_dz_track_metadata(track):
     year = track["album"].get("release_date", "").split("-")[0]  # Assuming the release_date is in YYYY-MM-DD format
     genre = track["album"].get("genre_id", "")
     url = track.get("link", "")
-    return Track(title, artist, album, url, year, genre)  # Assuming Track class is modified to include year and genre
+    # Extract ISRC - Deezer provides this at track level
+    isrc = track.get("isrc")
+    return Track(title, artist, album, url, year, genre, isrc)
 
 
 async def _get_dz_favorite_tracks(dz: deezer.Client, user_id: str) -> List[Track]:

--- a/plexist/modules/helperClasses.py
+++ b/plexist/modules/helperClasses.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
 
@@ -10,6 +10,7 @@ class Track:
     url: str
     year: str  
     genre: str
+    isrc: Optional[str] = None  # International Standard Recording Code for accurate matching
 
 
 @dataclass
@@ -38,6 +39,11 @@ class UserInputs:
 
     # Liked/Favorited tracks sync
     sync_liked_tracks: bool = False
+    
+    # Multi-service sync configuration
+    # Format: comma-separated pairs like "spotify:qobuz,tidal:plex"
+    # Each pair defines source:destination for playlist sync
+    sync_pairs: Optional[str] = None
 
     spotipy_client_id: Optional[str] = None
     spotipy_client_secret: Optional[str] = None

--- a/plexist/modules/orchestrator.py
+++ b/plexist/modules/orchestrator.py
@@ -1,0 +1,418 @@
+"""Sync Orchestrator for multi-service playlist synchronization.
+
+This module provides the SyncOrchestrator class that enables syncing playlists
+between any two music services (e.g., Spotify → Qobuz, Tidal → Plex).
+
+The orchestrator handles:
+- Reading playlists from a source service
+- Matching tracks in the destination service (using ISRC when available)
+- Creating/updating playlists in the destination service
+- Reporting on sync results (matched, missing, failed)
+"""
+import logging
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+from .base import MusicServiceProvider, ServiceRegistry
+from .helperClasses import Playlist, Track, UserInputs
+
+
+@dataclass
+class SyncResult:
+    """Result of a playlist sync operation."""
+    source: str
+    destination: str
+    playlist_name: str
+    total_tracks: int
+    matched_tracks: int
+    missing_tracks: int
+    failed_tracks: int
+    success: bool
+    error: Optional[str] = None
+
+
+@dataclass
+class SyncPair:
+    """Configuration for a sync pair."""
+    source_name: str
+    destination_name: str
+    
+    @classmethod
+    def parse(cls, pair_str: str) -> Optional["SyncPair"]:
+        """Parse a sync pair from string format 'source:destination'.
+        
+        Args:
+            pair_str: String in format 'source:destination' (e.g., 'spotify:qobuz')
+            
+        Returns:
+            SyncPair if valid, None otherwise
+        """
+        parts = pair_str.strip().lower().split(":")
+        if len(parts) != 2:
+            logging.warning("Invalid sync pair format: %s (expected 'source:destination')", pair_str)
+            return None
+        
+        source, destination = parts[0].strip(), parts[1].strip()
+        if not source or not destination:
+            logging.warning("Empty source or destination in sync pair: %s", pair_str)
+            return None
+        
+        if source == destination:
+            logging.warning("Source and destination cannot be the same: %s", pair_str)
+            return None
+        
+        return cls(source_name=source, destination_name=destination)
+    
+    @classmethod
+    def parse_multiple(cls, pairs_str: str) -> List["SyncPair"]:
+        """Parse multiple sync pairs from comma-separated string.
+        
+        Args:
+            pairs_str: Comma-separated sync pairs (e.g., 'spotify:qobuz,tidal:plex')
+            
+        Returns:
+            List of valid SyncPair objects
+        """
+        if not pairs_str:
+            return []
+        
+        pairs = []
+        for pair_str in pairs_str.split(","):
+            pair = cls.parse(pair_str)
+            if pair:
+                pairs.append(pair)
+        
+        return pairs
+
+
+class SyncOrchestrator:
+    """Orchestrates playlist synchronization between music services.
+    
+    The orchestrator follows a unidirectional sync pattern:
+    1. Fetch playlists from the source service
+    2. For each playlist, fetch its tracks
+    3. Match tracks in the destination service (ISRC-first, then metadata)
+    4. Create or update the playlist in the destination service
+    5. Report results
+    """
+    
+    def __init__(self, user_inputs: UserInputs):
+        self.user_inputs = user_inputs
+        self._results: List[SyncResult] = []
+    
+    @property
+    def results(self) -> List[SyncResult]:
+        """Get all sync results from the last run."""
+        return self._results
+    
+    def _get_provider(self, name: str) -> Optional[MusicServiceProvider]:
+        """Get a provider by name."""
+        provider = ServiceRegistry.get_provider(name)
+        if not provider:
+            logging.error("Unknown provider: %s", name)
+            return None
+        return provider
+    
+    def _validate_pair(
+        self, 
+        pair: SyncPair
+    ) -> Tuple[Optional[MusicServiceProvider], Optional[MusicServiceProvider], Optional[str]]:
+        """Validate a sync pair and return the providers.
+        
+        Returns:
+            Tuple of (source_provider, destination_provider, error_message)
+        """
+        source = self._get_provider(pair.source_name)
+        if not source:
+            return None, None, f"Source provider '{pair.source_name}' not found"
+        
+        destination = self._get_provider(pair.destination_name)
+        if not destination:
+            return None, None, f"Destination provider '{pair.destination_name}' not found"
+        
+        if not source.is_configured(self.user_inputs):
+            return None, None, f"Source provider '{pair.source_name}' is not configured"
+        
+        if not destination.is_configured(self.user_inputs):
+            return None, None, f"Destination provider '{pair.destination_name}' is not configured"
+        
+        if not source.supports_read:
+            return None, None, f"Source provider '{pair.source_name}' does not support reading"
+        
+        if not destination.supports_write:
+            return None, None, f"Destination provider '{pair.destination_name}' does not support writing"
+        
+        return source, destination, None
+    
+    async def sync_playlist(
+        self,
+        source: MusicServiceProvider,
+        destination: MusicServiceProvider,
+        playlist: Playlist,
+        tracks: List[Track],
+    ) -> SyncResult:
+        """Sync a single playlist from source to destination.
+        
+        Args:
+            source: Source provider
+            destination: Destination provider  
+            playlist: Playlist metadata
+            tracks: List of tracks to sync
+            
+        Returns:
+            SyncResult with details of the operation
+        """
+        result = SyncResult(
+            source=source.name,
+            destination=destination.name,
+            playlist_name=playlist.name,
+            total_tracks=len(tracks),
+            matched_tracks=0,
+            missing_tracks=0,
+            failed_tracks=0,
+            success=False,
+        )
+        
+        if not tracks:
+            logging.warning(
+                "No tracks to sync for playlist '%s' from %s to %s",
+                playlist.name, source.name, destination.name
+            )
+            result.success = True
+            return result
+        
+        try:
+            # Match tracks in destination service
+            logging.info(
+                "Matching %d tracks in %s for playlist '%s'",
+                len(tracks), destination.name, playlist.name
+            )
+            
+            matched: List[Tuple[Track, str]] = []
+            missing: List[Track] = []
+            
+            for track in tracks:
+                try:
+                    track_id = await destination.search_track(track, self.user_inputs)
+                    if track_id:
+                        matched.append((track, track_id))
+                    else:
+                        missing.append(track)
+                except Exception as e:
+                    logging.debug(
+                        "Error matching track '%s' by '%s': %s",
+                        track.title, track.artist, e
+                    )
+                    missing.append(track)
+            
+            result.matched_tracks = len(matched)
+            result.missing_tracks = len(missing)
+            
+            logging.info(
+                "Matched %d/%d tracks for playlist '%s' in %s",
+                len(matched), len(tracks), playlist.name, destination.name
+            )
+            
+            if not matched:
+                logging.warning(
+                    "No tracks matched in %s for playlist '%s', skipping creation",
+                    destination.name, playlist.name
+                )
+                result.success = True  # Not a failure, just no matches
+                return result
+            
+            # Check if playlist already exists in destination
+            existing_playlist = await destination.get_playlist_by_name(
+                playlist.name, self.user_inputs
+            )
+            
+            if existing_playlist:
+                # Update existing playlist - clear and re-add
+                logging.info(
+                    "Updating existing playlist '%s' in %s",
+                    playlist.name, destination.name
+                )
+                playlist_id = existing_playlist.id
+                
+                # Clear existing tracks if not appending
+                if not self.user_inputs.append_instead_of_sync:
+                    await destination.clear_playlist(playlist_id, self.user_inputs)
+            else:
+                # Create new playlist
+                logging.info(
+                    "Creating new playlist '%s' in %s",
+                    playlist.name, destination.name
+                )
+                playlist_id = await destination.create_playlist(playlist, self.user_inputs)
+            
+            # Add matched tracks
+            track_ids = [tid for _, tid in matched]
+            added = await destination.add_tracks_to_playlist(
+                playlist_id, track_ids, self.user_inputs
+            )
+            
+            result.failed_tracks = len(matched) - added
+            result.success = True
+            
+            logging.info(
+                "Synced playlist '%s' from %s to %s: %d matched, %d missing, %d failed",
+                playlist.name, source.name, destination.name,
+                result.matched_tracks, result.missing_tracks, result.failed_tracks
+            )
+            
+        except Exception as e:
+            result.error = str(e)
+            logging.error(
+                "Failed to sync playlist '%s' from %s to %s: %s",
+                playlist.name, source.name, destination.name, e
+            )
+        
+        return result
+    
+    async def sync_pair(self, pair: SyncPair) -> List[SyncResult]:
+        """Sync all playlists for a single source→destination pair.
+        
+        Args:
+            pair: SyncPair configuration
+            
+        Returns:
+            List of SyncResult for each playlist
+        """
+        results: List[SyncResult] = []
+        
+        source, destination, error = self._validate_pair(pair)
+        if error:
+            logging.error("Cannot sync %s → %s: %s", pair.source_name, pair.destination_name, error)
+            return results
+        
+        assert source is not None and destination is not None
+        
+        logging.info(
+            "Starting sync from %s to %s",
+            source.name, destination.name
+        )
+        
+        try:
+            # Fetch playlists from source
+            playlists = await source.get_playlists(self.user_inputs)
+            
+            if not playlists:
+                logging.warning("No playlists found in %s", source.name)
+                return results
+            
+            logging.info("Found %d playlists in %s", len(playlists), source.name)
+            
+            # Sync each playlist
+            for playlist in playlists:
+                logging.info(
+                    "Syncing playlist '%s' from %s to %s",
+                    playlist.name, source.name, destination.name
+                )
+                
+                # Fetch tracks from source
+                tracks = await source.get_tracks(playlist, self.user_inputs)
+                
+                # Sync to destination
+                result = await self.sync_playlist(source, destination, playlist, tracks)
+                results.append(result)
+            
+        except Exception as e:
+            logging.error(
+                "Error during sync from %s to %s: %s",
+                source.name, destination.name, e
+            )
+        
+        return results
+    
+    async def sync_all(self, pairs: List[SyncPair]) -> List[SyncResult]:
+        """Sync all configured source→destination pairs.
+        
+        Args:
+            pairs: List of SyncPair configurations
+            
+        Returns:
+            List of all SyncResult objects
+        """
+        self._results = []
+        
+        if not pairs:
+            logging.warning("No sync pairs configured")
+            return self._results
+        
+        logging.info("Starting multi-service sync with %d pair(s)", len(pairs))
+        
+        for pair in pairs:
+            pair_results = await self.sync_pair(pair)
+            self._results.extend(pair_results)
+        
+        # Summary
+        total_playlists = len(self._results)
+        successful = sum(1 for r in self._results if r.success)
+        total_matched = sum(r.matched_tracks for r in self._results)
+        total_missing = sum(r.missing_tracks for r in self._results)
+        
+        logging.info(
+            "Multi-service sync complete: %d/%d playlists synced, %d tracks matched, %d tracks missing",
+            successful, total_playlists, total_matched, total_missing
+        )
+        
+        return self._results
+    
+    def print_summary(self) -> None:
+        """Print a summary of all sync results."""
+        if not self._results:
+            logging.info("No sync results to display")
+            return
+        
+        logging.info("=" * 60)
+        logging.info("SYNC SUMMARY")
+        logging.info("=" * 60)
+        
+        for result in self._results:
+            status = "✓" if result.success else "✗"
+            logging.info(
+                "%s %s → %s: '%s' (%d/%d tracks)",
+                status,
+                result.source,
+                result.destination,
+                result.playlist_name,
+                result.matched_tracks,
+                result.total_tracks,
+            )
+            if result.error:
+                logging.info("  Error: %s", result.error)
+        
+        logging.info("=" * 60)
+
+
+async def run_multi_service_sync(
+    user_inputs: UserInputs,
+    sync_pairs_str: Optional[str] = None,
+) -> List[SyncResult]:
+    """Convenience function to run multi-service sync.
+    
+    Args:
+        user_inputs: User configuration
+        sync_pairs_str: Comma-separated sync pairs (e.g., 'spotify:qobuz,tidal:plex')
+            If not provided, uses SYNC_PAIRS from user_inputs
+            
+    Returns:
+        List of SyncResult objects
+    """
+    pairs_str = sync_pairs_str or getattr(user_inputs, "sync_pairs", None)
+    
+    if not pairs_str:
+        logging.info("No sync pairs configured, skipping multi-service sync")
+        return []
+    
+    pairs = SyncPair.parse_multiple(pairs_str)
+    
+    if not pairs:
+        logging.warning("No valid sync pairs found in: %s", pairs_str)
+        return []
+    
+    orchestrator = SyncOrchestrator(user_inputs)
+    results = await orchestrator.sync_all(pairs)
+    orchestrator.print_summary()
+    
+    return results

--- a/plexist/modules/spotify.py
+++ b/plexist/modules/spotify.py
@@ -49,7 +49,9 @@ async def _get_sp_tracks_from_playlist(
         url = track["track"]["external_urls"].get("spotify", "")
         year = ""  # Default value
         genre = ""  # Default value
-        return Track(title, artist, album, url, year, genre)
+        # Extract ISRC from external_ids
+        isrc = track["track"].get("external_ids", {}).get("isrc")
+        return Track(title, artist, album, url, year, genre, isrc)
     sp_playlist_tracks = await asyncio.to_thread(
         sp.user_playlist_tracks, user_id, playlist.id
     )
@@ -85,7 +87,9 @@ async def _get_sp_liked_tracks(sp: spotipy.Spotify) -> List[Track]:
         url = track["external_urls"].get("spotify", "")
         year = track["album"].get("release_date", "")[:4] if track["album"].get("release_date") else ""
         genre = ""
-        return Track(title, artist, album, url, year, genre)
+        # Extract ISRC from external_ids
+        isrc = track.get("external_ids", {}).get("isrc")
+        return Track(title, artist, album, url, year, genre, isrc)
     
     tracks: List[Track] = []
     try:

--- a/plexist/settings.py
+++ b/plexist/settings.py
@@ -79,6 +79,12 @@ class PlexistSettings(BaseSettings):
     sync_liked_tracks: FlexibleBool = Field(
         default=False, validation_alias="SYNC_LIKED_TRACKS"
     )
+    
+    # Multi-service sync configuration
+    # Format: comma-separated pairs like "spotify:qobuz,tidal:plex"
+    sync_pairs: Optional[str] = Field(
+        default=None, validation_alias="SYNC_PAIRS"
+    )
 
     # Apple Music settings
     apple_music_team_id: Optional[str] = Field(
@@ -178,6 +184,7 @@ def build_user_inputs(settings: PlexistSettings) -> UserInputs:
         max_requests_per_second=settings.max_requests_per_second,
         max_concurrent_requests=settings.max_concurrent_requests,
         sync_liked_tracks=settings.sync_liked_tracks,
+        sync_pairs=settings.sync_pairs,
         spotipy_client_id=settings.spotipy_client_id,
         spotipy_client_secret=settings.spotipy_client_secret,
         spotify_user_id=settings.spotify_user_id,


### PR DESCRIPTION
- Add sync to qobuz and tidal
- ISRC-first matching: Uses International Standard Recording Codes for accurate cross-service track matching
- Metadata fallback: Falls back to title/artist/album matching when ISRC unavailable
- Write-capable providers: Qobuz, Tidal, and Plex support playlist creation and track addition
- Unidirectional sync: Source → Destination pattern
- Backwards compatible: Legacy Plex-centric sync works if no SYNC_PAIRS configured