### PR TITLE
fix(tidal): replace hardcoded token type with constant in session creation

### DIFF
--- a/plexist/modules/tidal.py
+++ b/plexist/modules/tidal.py
@@ -26,6 +26,8 @@ from .base import ServiceRegistry, MusicServiceProvider
 from .helperClasses import Playlist, Track, UserInputs
 from .plex import update_or_create_plex_playlist, sync_liked_tracks_to_plex
 
+TIDAL_OAUTH_TOKEN_TYPE = "Bearer"
+
 
 class TidalAuthError(Exception):
     """Authentication error with Tidal API."""
@@ -150,7 +152,7 @@ async def _create_authenticated_session(user_inputs: UserInputs) -> Optional[Any
         success = await _with_retries(
             lambda: asyncio.to_thread(
                 session.load_oauth_session,
-                tidalapi.SessionType.TIDAL,  # type: ignore[attr-defined]
+                TIDAL_OAUTH_TOKEN_TYPE,
                 access_token,
                 refresh_token,
                 token_expiry,

--- a/tests/test_tidal.py
+++ b/tests/test_tidal.py
@@ -321,12 +321,20 @@ class TestCreateAuthenticatedSession:
             mock_session.check_login = MagicMock(return_value=True)
             MockSession.return_value = mock_session
             
-            with patch("modules.tidal._with_retries", new_callable=AsyncMock) as mock_with_retries:
-                mock_with_retries.side_effect = [True, True]  # load_oauth_session, check_login
+            async def run_operation(operation, *_args):
+                return await operation()
+
+            with patch("modules.tidal._with_retries", side_effect=run_operation):
                 
                 session = await _create_authenticated_session(mock_user_inputs)
         
         assert session is not None
+        mock_session.load_oauth_session.assert_called_once_with(
+            "Bearer",
+            "test-access-token",
+            "test-refresh-token",
+            datetime(2025, 12, 31, 23, 59, 59),
+        )
 
     @pytest.mark.asyncio
     async def test_create_session_without_access_token(self, mock_user_inputs_unconfigured):


### PR DESCRIPTION
tidalapi==0.8.11 had no SessionType.TIDAL, so Tidal authentication failed.

Fixed in tidal.py by using the supported "Bearer" token type. Added regression coverage in test_tidal.py.